### PR TITLE
Pagination fix

### DIFF
--- a/app/assets/javascripts/backbone/entities/prop.coffee
+++ b/app/assets/javascripts/backbone/entities/prop.coffee
@@ -34,7 +34,7 @@
   API =
     getProps: (filters = {}) ->
       props = new Entities.Props
-      props.queryParams = filters
+      _.extend(props.queryParams, {})
       props.fetch()
       props
 


### PR DESCRIPTION
props.queryParams are populated by Backbone.Pagable so it should not be replaced with filters.