### PR TITLE
Set bot icon

### DIFF
--- a/app/services/notifier/slack_notifier.rb
+++ b/app/services/notifier/slack_notifier.rb
@@ -18,11 +18,16 @@ class Notifier
       default_options.merge!(text: notification.to_s)
     end
 
+    def icon
+      %w(:beers: :ok_hand:).sample
+    end
+
     def default_options
       {
         channel: AppConfig.slack.default_channel,
         username: 'PropsApp',
         color: '#0092ca',
+        icon_emoji: icon,
       }
     end
   end


### PR DESCRIPTION
Right now there's sad, grey-coloured robot. PropsApp bot should not be sad at all.