### PR TITLE
Use Heroku-specific "heroku-postbuild" script instead of generic "postinstall" hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "^1.12.1"
   },
   "scripts": {
-    "postinstall": "npm run build",
+    "heroku-postbuild": "npm run build",
     "build": "webpack -p --config webpack/production.config.js",
     "rwr-node-dev-server": "forever forever/development.json",
     "rwr-node-server": "forever -o log/rwr-server-out.log -e log/rwr-server-err.log forever/production.json",


### PR DESCRIPTION
Heroku provides us with possibly to define dedicated `heroku-postbuild` script in `package.json` file - let's use it, and actually force manual building of assets by `npm run build` (already described in README file).

Potential hurdles:

* Would be nice to actually try pushing to Heroku before merging - weird stuff happens, let's make sure it doesn't happen to us.
* We actually need `postinstall` script, as its used for something else than Heroku (what exactly? - thinking about Docker setup that may need altering, perhaps).