### PR TITLE
Fix broken urls in props

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Console](https://code.google.com/apis/console) and creating new project there.
 
 Development endpoints:
 
-- http://props.dev
-- http://props.dev/auth/google_oauth2/callback
+* http://props.dev
+* http://props.dev/auth/google_oauth2/callback
 
 When you have the credentials, put them in the `config/secrets.yml` file
 under `omniauth_provider_key` and `omniauth_provider_secret` values.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Console](https://code.google.com/apis/console) and creating new project there.
 
 Development endpoints:
 
-* http://props.dev
-* http://props.dev/auth/google_oauth2/callback
+- http://props.dev
+- http://props.dev/auth/google_oauth2/callback
 
 When you have the credentials, put them in the `config/secrets.yml` file
 under `omniauth_provider_key` and `omniauth_provider_secret` values.

--- a/app/notifications/new_prop_notification.rb
+++ b/app/notifications/new_prop_notification.rb
@@ -16,7 +16,7 @@ class NewPropNotification < BaseNotification
 
   def italicized_content
     prop.body.split("\n")
-           .map { |part_of_content| "_#{part_of_content}_" }
+           .map { |part_of_content| "_ #{part_of_content} _" }
            .join("\n")
   end
 

--- a/app/notifications/new_prop_notification.rb
+++ b/app/notifications/new_prop_notification.rb
@@ -16,8 +16,8 @@ class NewPropNotification < BaseNotification
 
   def italicized_content
     prop.body.split("\n")
-           .map { |part_of_content| "_ #{part_of_content} _" }
-           .join("\n")
+        .map { |part_of_content| "_ #{part_of_content} _" }
+        .join("\n")
   end
 
   def prop_receivers_list

--- a/spec/notifications/new_prop_notification_spec.rb
+++ b/spec/notifications/new_prop_notification_spec.rb
@@ -16,7 +16,7 @@ describe NewPropNotification do
     context 'when prop is single line' do
       let(:content) { 'Single line prop' }
       let(:part_of_expected_result) do
-        "_#{content}_"
+        "_ #{content} _"
       end
 
       it 'returns italized content' do
@@ -27,7 +27,7 @@ describe NewPropNotification do
     context 'when prop is multi line' do
       let(:content) { "Multi\nline\nprop" }
       let(:part_of_expected_result) do
-        "_Multi_\n_line_\n_prop_"
+        "_ Multi _\n_ line _\n_ prop _"
       end
 
       it 'returns italizes each line in content' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,9 +8,12 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
+require 'sidekiq/testing'
+
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
+Sidekiq::Testing.fake!
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
## Changes
- Add space before and after underscore sign when posting slack notification

## Why do I need this change?
- If someone adds link to his prop and app will end his url with `_` sign, this link won't work.