### PR TITLE
dont send 404 errors to rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,7 +1,7 @@
 require 'rollbar/rails'
 Rollbar.configure do |config|
   config.access_token = AppConfig.rollbar_access_token
-
+  config.exception_level_filters["ActionController::RoutingError"] = "ignore"
   if %w(development test).include?(Rails.env)
     config.enabled = false
   end


### PR DESCRIPTION
Implemented to solve [this problem](https://netguru.atlassian.net/browse/SUP-1542). Those errors needlessly eat our quota, so they should be ignored.