### PR TITLE
remove slack notifier options, so the main app icon is shown

### DIFF
--- a/app/services/notifier/slack_notifier.rb
+++ b/app/services/notifier/slack_notifier.rb
@@ -22,16 +22,9 @@ class Notifier
       default_options.merge!(text: notification.to_s)
     end
 
-    def icon
-      %w(:beers: :ok_hand:).sample
-    end
-
     def default_options
       {
         channel: AppConfig.slack.default_channel,
-        username: 'props',
-        color: '#0092ca',
-        icon_emoji: icon,
         as_user: false,
       }
     end


### PR DESCRIPTION
We will have a new icon now!