### PR TITLE
PROP-55 Fix typo in setup file command

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -21,7 +21,7 @@ Dir.chdir APP_ROOT do
   end
 
   puts "\n== Create DB user =="
-  system "creatuser -s -r props"
+  system "createuser -s -r props"
 
   puts "\n== Preparing database =="
   system "bin/rake db:setup"


### PR DESCRIPTION
## Changes
Fixed typo in Postgre user setup command. Changed `creatuser` to `createuser` command.
## Jira ticket
https://netguru.atlassian.net/browse/PROP-55