### PR TITLE
PROP-57 Production missing react_bundle.css fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
-docker/*
 docker-compose*

--- a/Capfile
+++ b/Capfile
@@ -2,6 +2,5 @@ require 'capistrano/setup'
 require 'capistrano/deploy'
 
 require 'capistrano/docker'
-require 'capistrano/docker/npm'
 require 'capistrano/docker/assets'
 require 'capistrano/docker/migration'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,9 +5,7 @@ set :docker_volumes, [
   "#{shared_path}/config/secrets.yml:/var/www/app/config/secrets.yml",
   "#{shared_path}/log:/var/www/app/log",
 
-  "props_production_node_modules:/var/www/app/node_modules",
   "props_production_assets:/var/www/app/public/assets",
-  "#{shared_path}/assets/javascripts/react_bundle.js:/var/www/app/app/assets/javascripts/react_bundle.js",
 ]
 
 set :docker_links, %w(postgres_ambassador:postgres redis_ambassador:redis)
@@ -16,15 +14,3 @@ set :docker_dockerfile, "docker/production/Dockerfile"
 
 set :docker_apparmor_profile, "docker-ptrace"
 set :docker_cpu_quota, "200000"
-
-namespace :docker do
-  namespace :npm do
-    task :build do
-      on roles(fetch(:docker_role)) do
-        execute :docker, task_command("npm run build")
-      end
-    end
-  end
-end
-
-after "docker:npm:install", "docker:npm:build"

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,19 +1,30 @@
 FROM quay.io/netguru/ng-ruby:2.2.3
 
+## Passenger
 RUN /opt/passenger/install
-RUN /opt/node/install
 
-# bundle dependencies
+## Node
+RUN \
+  curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+  apt-get install -y nodejs
+
+## YARN
+RUN \
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt-get update && apt-get install -y yarn
+
+## bundle dependencies
 RUN apt-get update && apt-get install -y libpq-dev
 
 ENV APP_HOME /var/www/app
 ENV RAILS_ENV=production
 ENV REDIS_URL=redis://redis:6379/0
 
-# set timezone
+## set timezone
 RUN echo 'Europe/Warsaw' > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
-# throw errors if Gemfile has been modified since Gemfile.lock
+## throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
 RUN mkdir -p $APP_HOME
@@ -25,6 +36,10 @@ RUN bundle install --jobs=8 --retry=3 --without development test --deployment
 ADD . $APP_HOME/
 ADD docker/production/entrypoint.sh /entrypoint.sh
 ADD docker/production/service/sidekiq /etc/service/sidekiq/run
+
+RUN yarn
+RUN npm run build
+RUN rm -rf node_modules
 
 # set cron tasks
 RUN bundle exec whenever --update-crontab --set environment=production

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -6,7 +6,7 @@ ENV PUMA_WORKERS 2
 RUN gem install puma
 
 ## Build react_bundle package
-RUN npm install
+RUN yarn
 RUN npm run build
 RUN rm -rf node_modules
 

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -6,7 +6,7 @@ ENV PUMA_WORKERS 2
 RUN gem install puma
 
 ## Build react_bundle package
-RUN yarn
+RUN npm install
 RUN npm run build
 RUN rm -rf node_modules
 


### PR DESCRIPTION
Staging is currently using yarn install and working properly. Production is currently using npm install (should probably use yarn). After deploying on production there is a problem with building react_bundle.css and some dependencies errors. This will check if the problem lies in mixed up dependencies, by hopefully breaking the staging. 
NOTE: This must be reversed or production deploy file must be changed in order to work properly on production.