### PR TITLE
Prop 67 store slack avatar

### DIFF
--- a/app/controllers/api/v1/entities/user_base.rb
+++ b/app/controllers/api/v1/entities/user_base.rb
@@ -11,7 +11,7 @@ module Api
         private
 
         def avatar_url
-          gravatar_url(object.email)
+          object.avatar || gravatar_url(object.email)
         end
 
         def gravatar_url(email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ActiveRecord::Base
   end
 
   def self.slack_attrs(member)
-    #TODO check it OUT!
+    # TODO check this OUT! It may be obsolete code.
     {
       provider: 'slack',
       uid: member['id'],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,10 +36,12 @@ class User < ActiveRecord::Base
       name: auth['info']['name'] || '',
       email: auth['info']['email'] || '',
       admin: auth['info']['is_admin'] || false,
+      avatar: auth['info']['image'] || '',
     }
   end
 
   def self.slack_attrs(member)
+    #TODO check it OUT!
     {
       provider: 'slack',
       uid: member['id'],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ActiveRecord::Base
   end
 
   def self.omniauth_user(auth)
-    find_by(email: auth['info']['email']) || find_by(name: auth['info']['nickname'])
+    find_by(uid: auth['uid']) || find_by(email: auth['info']['email'])
   end
 
   def self.omniauth_attrs(auth)
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
       uid: auth['uid'],
       name: auth['info']['name'] || '',
       email: auth['info']['email'] || '',
+      admin: auth['info']['is_admin'] || false,
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
       name: auth['info']['name'] || '',
       email: auth['info']['email'] || '',
       admin: auth['info']['is_admin'] || false,
-      avatar: auth['info']['image'] || '',
+      avatar: auth['extra']['user_info']['user']['profile']['image_512'] || '',
     }
   end
 

--- a/app/repositories/users_repository.rb
+++ b/app/repositories/users_repository.rb
@@ -18,10 +18,7 @@ class UsersRepository
   delegate :find_by_email, :find_by_name, to: :all
 
   def user_from_auth(auth)
-    active.where(
-      provider: auth['provider'],
-      uid: auth['uid'].to_s,
-    ).first || User.create_with_omniauth(auth)
+    User.create_with_omniauth(auth)
   end
 
   def user_from_slack(member)

--- a/app/services/users/sign_in.rb
+++ b/app/services/users/sign_in.rb
@@ -10,19 +10,9 @@ module Users
 
     def call
       user = @users_repository.user_from_auth(@auth)
-      update_user(user)
       organisation = @organisations_repository.from_auth(@auth)
       organisation.add_user(user)
       Membership.find_by(user: user, organisation: organisation)
-    end
-
-    private
-
-    def update_user(user)
-      email = @auth['info']['email']
-      name = @auth['info']['name']
-      admin = @auth['info']['is_admin']
-      user.update_attributes(email: email, name: name, admin: admin)
     end
   end
 end

--- a/db/migrate/20170601204451_add_avatar_to_users.rb
+++ b/db/migrate/20170601204451_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517154118) do
+ActiveRecord::Schema.define(version: 20170601204451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 20170517154118) do
     t.datetime "updated_at"
     t.boolean  "admin",       default: false
     t.datetime "archived_at"
+    t.string   "avatar"
   end
 
   add_index "users", ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true, using: :btree

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :user do
     sequence(:name) { |n| "username_#{n}" }
     sequence(:email) { |n| "user_#{n}@email.com" }
+    sequence(:avatar) { |n| "user_#{n}.slack.com/avatar.png" }
     provider 'provider'
     uid { FFaker::Guid.guid }
 

--- a/spec/repositories/users_repository_spec.rb
+++ b/spec/repositories/users_repository_spec.rb
@@ -18,7 +18,8 @@ describe UsersRepository do
 
   describe '#user_from_auth' do
     new_email = 'different@email.com'
-    let(:auth) { create_auth(email: new_email) }
+    new_avatar = 'slack.com/new_avatar.png'
+    let(:auth) { create_auth(email: new_email, avatar: new_avatar) }
     let(:user_with_uid) { create(:user, uid: auth['uid']) }
 
     subject { repo.user_from_auth(auth) }
@@ -31,6 +32,12 @@ describe UsersRepository do
       user_with_uid
       subject
       expect(user_with_uid.reload.email).to eq(new_email)
+    end
+
+    it "updates user's avatar when it's different from one in the database" do
+      user_with_uid
+      subject
+      expect(user_with_uid.reload.avatar).to eq(new_avatar)
     end
 
     it 'saves user as admin if is_admin is true' do

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -3,6 +3,7 @@ module OmniauthHelpers
                   token: 'valid_token',
                   team_id: 'team_id',
                   team_name: 'team_name',
+                  avatar: 'slack.com/sample_avatar.png',
                   is_admin: false)
     {
       'provider' => 'slack',
@@ -14,6 +15,15 @@ module OmniauthHelpers
         'team_id' => team_id,
         'team' => team_name,
         'is_admin' => is_admin,
+      },
+      'extra' => {
+        'user_info' => {
+          'user' => {
+            'profile' => {
+              'image_512' => avatar,
+            },
+          },
+        },
       },
       'credentials' => { 'token' => token },
     }


### PR DESCRIPTION
Save url to slack avatar upon login
- Add db column for avatar url
- Save avatar upon login
- Serialize saved avatar OR gravatar if there is no avatar saved
- Test functionality