### PR TITLE
Prop 67 store slack avatar

### DIFF
--- a/app/controllers/api/v1/entities/user_base.rb
+++ b/app/controllers/api/v1/entities/user_base.rb
@@ -11,7 +11,7 @@ module Api
         private
 
         def avatar_url
-          gravatar_url(object.email)
+          object.avatar || gravatar_url(object.email)
         end
 
         def gravatar_url(email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ActiveRecord::Base
   end
 
   def self.slack_attrs(member)
-    # TODO check this OUT! It may be obsolete code.
+    # TODO: check this OUT! It may be obsolete code.
     {
       provider: 'slack',
       uid: member['id'],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
       name: auth['info']['name'] || '',
       email: auth['info']['email'] || '',
       admin: auth['info']['is_admin'] || false,
-      avatar: auth['extra']['user_info']['user']['profile']['image_512'] || '',
+      avatar: auth.dig('extra', 'user_info', 'user', 'profile', 'image_512') || '',
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ActiveRecord::Base
   end
 
   def self.slack_attrs(member)
-    #TODO check it OUT!
+    # TODO check this OUT! It may be obsolete code.
     {
       provider: 'slack',
       uid: member['id'],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,10 +36,12 @@ class User < ActiveRecord::Base
       name: auth['info']['name'] || '',
       email: auth['info']['email'] || '',
       admin: auth['info']['is_admin'] || false,
+      avatar: auth['info']['image'] || '',
     }
   end
 
   def self.slack_attrs(member)
+    #TODO check it OUT!
     {
       provider: 'slack',
       uid: member['id'],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
       name: auth['info']['name'] || '',
       email: auth['info']['email'] || '',
       admin: auth['info']['is_admin'] || false,
-      avatar: auth['info']['image'] || '',
+      avatar: auth['extra']['user_info']['user']['profile']['image_512'] || '',
     }
   end
 

--- a/db/migrate/20170601204451_add_avatar_to_users.rb
+++ b/db/migrate/20170601204451_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517154118) do
+ActiveRecord::Schema.define(version: 20170601204451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 20170517154118) do
     t.datetime "updated_at"
     t.boolean  "admin",       default: false
     t.datetime "archived_at"
+    t.string   "avatar"
   end
 
   add_index "users", ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true, using: :btree

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :user do
     sequence(:name) { |n| "username_#{n}" }
     sequence(:email) { |n| "user_#{n}@email.com" }
+    sequence(:avatar) { |n| "user_#{n}.slack.com/avatar.png" }
     provider 'provider'
     uid { FFaker::Guid.guid }
 

--- a/spec/repositories/users_repository_spec.rb
+++ b/spec/repositories/users_repository_spec.rb
@@ -18,7 +18,8 @@ describe UsersRepository do
 
   describe '#user_from_auth' do
     new_email = 'different@email.com'
-    let(:auth) { create_auth(email: new_email) }
+    new_avatar = 'slack.com/new_avatar.png'
+    let(:auth) { create_auth(email: new_email, avatar: new_avatar) }
     let(:user_with_uid) { create(:user, uid: auth['uid']) }
 
     subject { repo.user_from_auth(auth) }
@@ -31,6 +32,12 @@ describe UsersRepository do
       user_with_uid
       subject
       expect(user_with_uid.reload.email).to eq(new_email)
+    end
+
+    it "updates user's avatar when it's different from one in the database" do
+      user_with_uid
+      subject
+      expect(user_with_uid.reload.avatar).to eq(new_avatar)
     end
 
     it 'saves user as admin if is_admin is true' do

--- a/spec/repositories/users_repository_spec.rb
+++ b/spec/repositories/users_repository_spec.rb
@@ -1,34 +1,34 @@
-require "rails_helper"
+require 'rails_helper'
 include OmniauthHelpers
 
 describe UsersRepository do
-  let(:user) { create(:user, name: "John Doe", email: "user@example.com") }
+  let(:user) { create(:user, name: 'John Doe', email: 'user@example.com') }
   let(:archived_user) { create(:user, archived_at: Time.now) }
   let(:repo) { described_class.new }
 
-  describe "#find_by_id" do
-    it "returns active user" do
+  describe '#find_by_id' do
+    it 'returns active user' do
       expect(repo.find_by_id(user.id)).to eq(user)
     end
 
-    it "returns archived users" do
+    it 'returns archived users' do
       expect(repo.find_by_id(archived_user.id)).to eq(archived_user)
     end
   end
 
-  describe "#user_from_auth" do
-    let(:new_email) { "different@email.com" }
-    let(:new_avatar) { "slack.com/new_avatar.png" }
+  describe '#user_from_auth' do
+    let(:new_email) { 'different@email.com' }
+    let(:new_avatar) { 'slack.com/new_avatar.png' }
     let(:auth) { create_auth(email: new_email, avatar: new_avatar) }
 
     subject { repo.user_from_auth(auth) }
 
-    it "returns user object" do
+    it 'returns user object' do
       expect(subject).to eq(User.first)
     end
 
-    context "when user is already in the database" do
-      let!(:user_with_uid) { create(:user, uid: auth["uid"]) }
+    context 'when user is already in the database' do
+      let!(:user_with_uid) { create(:user, uid: auth['uid']) }
 
       it "updates user's email when it's different from one in the database" do
         subject
@@ -41,72 +41,72 @@ describe UsersRepository do
       end
     end
 
-    context "when auth is_admin is true" do
+    context 'when auth is_admin is true' do
       let(:auth) { create_auth(is_admin: true) }
 
-      it "saves user as admin" do
+      it 'saves user as admin' do
         subject
         expect(User.first.admin).to eq true
       end
     end
 
-    context "when auth is_admin is false" do
+    context 'when auth is_admin is false' do
       let(:auth) { create_auth(is_admin: false) }
 
-      it "does not save user as admin" do
+      it 'does not save user as admin' do
         subject
         expect(User.first.admin).to eq false
       end
     end
   end
 
-  describe "#user_from_slack" do
+  describe '#user_from_slack' do
     let(:slack_member) do
       {
-        "profile" => {
-          "email" => email,
-          "real_name" => name,
+        'profile' => {
+          'email' => email,
+          'real_name' => name,
         },
       }
     end
 
     before do
-      AppConfig.stub(:[]).with("domain_name").and_return("example.com")
-      AppConfig.stub(:[]).with("extra_domains").and_return("example.co")
+      AppConfig.stub(:[]).with('domain_name').and_return('example.com')
+      AppConfig.stub(:[]).with('extra_domains').and_return('example.co')
       user.reload
     end
 
-    context "email recieved from slack is matching" do
-      let(:email) { "user@example.com" }
-      let(:name) { "John F Kennedy" }
+    context 'email recieved from slack is matching' do
+      let(:email) { 'user@example.com' }
+      let(:name) { 'John F Kennedy' }
 
-      it "returns correct user" do
+      it 'returns correct user' do
         expect(repo.user_from_slack(slack_member)).to eq(user)
       end
     end
 
-    context "local part of email is matching and domain is allowed by extra_domains" do
-      let(:email) { "user@example.co" }
-      let(:name) { "John F Kennedy" }
+    context 'local part of email is matching and domain is allowed by extra_domains' do
+      let(:email) { 'user@example.co' }
+      let(:name) { 'John F Kennedy' }
 
-      it "returns correct user" do
+      it 'returns correct user' do
         expect(repo.user_from_slack(slack_member)).to eq(user)
       end
     end
 
-    context "email is not reconized" do
-      let(:email) { "wrong@email.co" }
+    context 'email is not reconized' do
+      let(:email) { 'wrong@email.co' }
 
-      context "name is matching" do
-        let(:name) { "John Doe" }
+      context 'name is matching' do
+        let(:name) { 'John Doe' }
 
-        it "returns correct user" do
+        it 'returns correct user' do
           expect(repo.user_from_slack(slack_member)).to eq(user)
         end
       end
 
-      context "name is not matching" do
-        let(:name) { "John F Kennedy" }
+      context 'name is not matching' do
+        let(:name) { 'John F Kennedy' }
 
         subject { repo.user_from_slack(slack_member) }
 

--- a/spec/repositories/users_repository_spec.rb
+++ b/spec/repositories/users_repository_spec.rb
@@ -1,105 +1,112 @@
-require 'rails_helper'
+require "rails_helper"
 include OmniauthHelpers
 
 describe UsersRepository do
-  let(:user) { create(:user, name: 'John Doe', email: 'user@example.com') }
+  let(:user) { create(:user, name: "John Doe", email: "user@example.com") }
   let(:archived_user) { create(:user, archived_at: Time.now) }
   let(:repo) { described_class.new }
 
-  describe '#find_by_id' do
-    it 'returns active user' do
+  describe "#find_by_id" do
+    it "returns active user" do
       expect(repo.find_by_id(user.id)).to eq(user)
     end
 
-    it 'returns archived users' do
+    it "returns archived users" do
       expect(repo.find_by_id(archived_user.id)).to eq(archived_user)
     end
   end
 
-  describe '#user_from_auth' do
-    new_email = 'different@email.com'
-    new_avatar = 'slack.com/new_avatar.png'
+  describe "#user_from_auth" do
+    let(:new_email) { "different@email.com" }
+    let(:new_avatar) { "slack.com/new_avatar.png" }
     let(:auth) { create_auth(email: new_email, avatar: new_avatar) }
-    let(:user_with_uid) { create(:user, uid: auth['uid']) }
 
     subject { repo.user_from_auth(auth) }
 
-    it 'returns user object' do
+    it "returns user object" do
       expect(subject).to eq(User.first)
     end
 
-    it "updates user's email when it's different from one in the database" do
-      user_with_uid
-      subject
-      expect(user_with_uid.reload.email).to eq(new_email)
+    context "when user is already in the database" do
+      let!(:user_with_uid) { create(:user, uid: auth["uid"]) }
+
+      it "updates user's email when it's different from one in the database" do
+        subject
+        expect(user_with_uid.reload.email).to eq(new_email)
+      end
+
+      it "updates user's avatar when it's different from one in the database" do
+        subject
+        expect(user_with_uid.reload.avatar).to eq(new_avatar)
+      end
     end
 
-    it "updates user's avatar when it's different from one in the database" do
-      user_with_uid
-      subject
-      expect(user_with_uid.reload.avatar).to eq(new_avatar)
+    context "when auth is_admin is true" do
+      let(:auth) { create_auth(is_admin: true) }
+
+      it "saves user as admin" do
+        subject
+        expect(User.first.admin).to eq true
+      end
     end
 
-    it 'saves user as admin if is_admin is true' do
-      auth['info']['is_admin'] = true
-      subject
-      expect(User.first.admin).to eq true
-    end
+    context "when auth is_admin is false" do
+      let(:auth) { create_auth(is_admin: false) }
 
-    it 'does not save user as admin if is_admin is false' do
-      auth['info']['is_admin'] = false
-      subject
-      expect(User.first.admin).to eq false
+      it "does not save user as admin" do
+        subject
+        expect(User.first.admin).to eq false
+      end
     end
   end
 
-  describe '#user_from_slack' do
+  describe "#user_from_slack" do
     let(:slack_member) do
       {
-        'profile' => {
-          'email' => email,
-          'real_name' => name,
+        "profile" => {
+          "email" => email,
+          "real_name" => name,
         },
       }
     end
 
     before do
-      AppConfig.stub(:[]).with('domain_name').and_return('example.com')
-      AppConfig.stub(:[]).with('extra_domains').and_return('example.co')
+      AppConfig.stub(:[]).with("domain_name").and_return("example.com")
+      AppConfig.stub(:[]).with("extra_domains").and_return("example.co")
       user.reload
     end
 
-    context 'email recieved from slack is matching' do
-      let(:email) { 'user@example.com' }
-      let(:name) { 'John F Kennedy' }
+    context "email recieved from slack is matching" do
+      let(:email) { "user@example.com" }
+      let(:name) { "John F Kennedy" }
 
-      it 'returns correct user' do
+      it "returns correct user" do
         expect(repo.user_from_slack(slack_member)).to eq(user)
       end
     end
 
-    context 'local part of email is matching and domain is allowed by extra_domains' do
-      let(:email) { 'user@example.co' }
-      let(:name) { 'John F Kennedy' }
+    context "local part of email is matching and domain is allowed by extra_domains" do
+      let(:email) { "user@example.co" }
+      let(:name) { "John F Kennedy" }
 
-      it 'returns correct user' do
+      it "returns correct user" do
         expect(repo.user_from_slack(slack_member)).to eq(user)
       end
     end
 
-    context 'email is not reconized' do
-      let(:email) { 'wrong@email.co' }
+    context "email is not reconized" do
+      let(:email) { "wrong@email.co" }
 
-      context 'name is matching' do
-        let(:name) { 'John Doe' }
+      context "name is matching" do
+        let(:name) { "John Doe" }
 
-        it 'returns correct user' do
+        it "returns correct user" do
           expect(repo.user_from_slack(slack_member)).to eq(user)
         end
       end
 
-      context 'name is not matching' do
-        let(:name) { 'John F Kennedy' }
+      context "name is not matching" do
+        let(:name) { "John F Kennedy" }
 
         subject { repo.user_from_slack(slack_member) }
 

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -3,6 +3,7 @@ module OmniauthHelpers
                   token: 'valid_token',
                   team_id: 'team_id',
                   team_name: 'team_name',
+                  avatar: 'slack.com/sample_avatar.png',
                   is_admin: false)
     {
       'provider' => 'slack',
@@ -14,6 +15,15 @@ module OmniauthHelpers
         'team_id' => team_id,
         'team' => team_name,
         'is_admin' => is_admin,
+      },
+      'extra' => {
+        'user_info' => {
+          'user' => {
+            'profile' => {
+              'image_512' => avatar,
+            },
+          },
+        },
       },
       'credentials' => { 'token' => token },
     }


### PR DESCRIPTION
Save url to slack avatar upon login
- Add db column for avatar url
- Save avatar upon login
- Serialize saved avatar OR gravatar if there is no avatar saved
- Test functionality