### PR TITLE
Assign small avatar when big is blank

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
       name: auth['info']['name'] || '',
       email: auth['info']['email'] || '',
       admin: auth['info']['is_admin'] || false,
-      avatar: auth.dig('extra', 'user_info', 'user', 'profile', 'image_512') || '',
+      avatar: big_avatar_512(auth) || small_avatar_192(auth),
     }
   end
 
@@ -48,5 +48,17 @@ class User < ActiveRecord::Base
       name: member['profile']['real_name'] || '',
       email: member['profile']['email'] || '',
     }
+  end
+
+  class << self
+    private
+
+    def big_avatar_512(auth)
+      auth.dig('extra', 'user_info', 'user', 'profile', 'image_512')
+    end
+
+    def small_avatar_192(auth)
+      auth['info']['image']
+    end
   end
 end

--- a/spec/repositories/users_repository_spec.rb
+++ b/spec/repositories/users_repository_spec.rb
@@ -18,8 +18,8 @@ describe UsersRepository do
 
   describe '#user_from_auth' do
     let(:new_email) { 'different@email.com' }
-    let(:new_avatar) { 'slack.com/new_avatar.png' }
-    let(:auth) { create_auth(email: new_email, avatar: new_avatar) }
+    let(:big_avatar) { 'slack.com/big_avatar.png' }
+    let(:auth) { create_auth(email: new_email, big_avatar: big_avatar) }
 
     subject { repo.user_from_auth(auth) }
 
@@ -37,7 +37,17 @@ describe UsersRepository do
 
       it "updates user's avatar when it's different from one in the database" do
         subject
-        expect(user_with_uid.reload.avatar).to eq(new_avatar)
+        expect(user_with_uid.reload.avatar).to eq(big_avatar)
+      end
+
+      context 'when big avatar in auth hash is nil' do
+        let(:small_avatar) { 'slack.com/small_avatar.png' }
+        let(:auth) { create_auth(email: new_email, big_avatar: nil, small_avatar: small_avatar) }
+
+        it 'assigns small avatar' do
+          subject
+          expect(user_with_uid.reload.avatar).to eq(small_avatar)
+        end
       end
     end
 

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -3,7 +3,8 @@ module OmniauthHelpers
                   token: 'valid_token',
                   team_id: 'team_id',
                   team_name: 'team_name',
-                  avatar: 'slack.com/sample_avatar.png',
+                  small_avatar: 'slack.com/sample_small_avatar_192.png',
+                  big_avatar: 'slack.com/sample_avatar.png',
                   is_admin: false)
     {
       'provider' => 'slack',
@@ -15,12 +16,13 @@ module OmniauthHelpers
         'team_id' => team_id,
         'team' => team_name,
         'is_admin' => is_admin,
+        'image' => small_avatar,
       },
       'extra' => {
         'user_info' => {
           'user' => {
             'profile' => {
-              'image_512' => avatar,
+              'image_512' => big_avatar,
             },
           },
         },


### PR DESCRIPTION
Production bug fix - use small avatar when big isn't present. When both are nil use gravatar (already implemented in `user_base` but required changes in user attributes).