### PR TITLE
Prop-69 Update all users in organisation

### DIFF
--- a/app/controllers/api/v1/helpers.rb
+++ b/app/controllers/api/v1/helpers.rb
@@ -11,6 +11,10 @@ module Api
         error!('401 Unauthorized', 401) if current_user.nil?
       end
 
+      def authenticate_admin!
+        error!('401 Unauthorized', 401) unless current_user.admin?
+      end
+
       def require_api_auth!(token)
         return if current_user.present?
         error!('Invalid token', 401) unless token_valid?(token)

--- a/app/controllers/api/v1/users.rb
+++ b/app/controllers/api/v1/users.rb
@@ -33,6 +33,12 @@ module Api
             present user, with: Entities::UserFull, organisation: current_organisation
           end
         end
+
+        desc 'Downloads users from Slack and creates/updates them'
+        post :download_users do
+          authenticate_admin!
+          ::Users::DownloadUsers.new(organisation: current_organisation).call
+        end
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,22 +26,12 @@ class User < ActiveRecord::Base
     end
   end
 
-  def self.update_with_slack_fetch(user_info)
-    slack_user(user_info).tap do |user|
-      user.update slack_fetch_attrs(user_info)
-    end
-  end
-
   def self.create_from_slack(member)
     create! slack_attrs(member)
   end
 
   def self.omniauth_user(auth)
     find_by(uid: auth['uid']) || find_by(email: auth['info']['email'])
-  end
-
-  def self.slack_user(user_info)
-    find_by(uid: user_info['id']) || find_by(email: user_info['profile']['email'])
   end
 
   def self.omniauth_attrs(auth)
@@ -52,17 +42,6 @@ class User < ActiveRecord::Base
       email: auth['info']['email'] || '',
       admin: auth['info']['is_admin'] || false,
       avatar: big_avatar_512(auth) || small_avatar_192(auth),
-    }
-  end
-
-  def self.slack_fetch_attrs(user_info)
-    {
-      provider: 'slack',
-      uid: user_info['id'],
-      name: name_from_user_info(user_info),
-      email: user_info['profile']['email'] || '',
-      admin: user_info['is_admin'] || false,
-      avatar: user_info['profile']['image_512'],
     }
   end
 
@@ -79,16 +58,37 @@ class User < ActiveRecord::Base
   class << self
     private
 
+    def update_with_slack_fetch(user_info)
+      slack_user(user_info).tap do |user|
+        user.update slack_fetch_attrs(user_info)
+      end
+    end
+
+    def slack_user(user_info)
+      find_by(uid: user_info['id']) || find_by(email: user_info['profile']['email'])
+    end
+
+    def slack_fetch_attrs(user_info)
+      {
+        provider: 'slack',
+        uid: user_info['id'],
+        name: name_from_user_info(user_info),
+        email: user_info['profile']['email'] || '',
+        admin: user_info['is_admin'] || false,
+        avatar: user_info['profile']['image_512'],
+      }
+    end
+
+    def name_from_user_info(user_info)
+      user_info['real_name'].blank? ? user_info['name'] : user_info['real_name']
+    end
+
     def big_avatar_512(auth)
       auth.dig('extra', 'user_info', 'user', 'profile', 'image_512')
     end
 
     def small_avatar_192(auth)
       auth['info']['image']
-    end
-
-    def name_from_user_info(user_info)
-      user_info['real_name'].blank? ? user_info['name'] : user_info['real_name']
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,15 +59,11 @@ class User < ActiveRecord::Base
     {
       provider: 'slack',
       uid: user_info['id'],
-      name: (user_info['real_name'].blank? ? user_info['name'] : user_info['real_name']),
+      name: name_from_user_info(user_info),
       email: user_info['profile']['email'] || '',
       admin: user_info['is_admin'] || false,
-      avatar: user_info['profile']['image_512'] || '',
+      avatar: user_info['profile']['image_512'],
     }
-  end
-
-  def name_from_user_info
-    user_info['real_name'].blank? ? user_info['real_name'] : 'x'
   end
 
   def self.slack_attrs(member)
@@ -89,6 +85,10 @@ class User < ActiveRecord::Base
 
     def small_avatar_192(auth)
       auth['info']['image']
+    end
+
+    def name_from_user_info(user_info)
+      user_info['real_name'].blank? ? user_info['name'] : user_info['real_name']
     end
   end
 end

--- a/app/repositories/users_repository.rb
+++ b/app/repositories/users_repository.rb
@@ -21,6 +21,10 @@ class UsersRepository
     User.create_with_omniauth(auth)
   end
 
+  def user_from_slack_fetch(user_info)
+    User.create_with_slack_fetch(user_info)
+  end
+
   def user_from_slack(member)
     find_by_member(member) || (report_matching_error(member) && User.create_from_slack(member))
   end

--- a/app/services/users/download_users.rb
+++ b/app/services/users/download_users.rb
@@ -15,7 +15,6 @@ module Users
     def create_or_update_users(organisation)
       users_array(organisation).each do |user_info|
         next if bot?(user_info)
-        puts user_info['name']
         user = users_repository.user_from_slack_fetch(user_info)
         organisation.add_user(user)
       end

--- a/app/services/users/download_users.rb
+++ b/app/services/users/download_users.rb
@@ -1,0 +1,45 @@
+module Users
+  class DownloadUsers
+    def call
+      fetch_users_from_every_organisation
+    end
+
+    private
+
+    def fetch_users_from_every_organisation
+      Organisation.all.each do |organisation|
+        create_or_update_users(organisation)
+      end
+    end
+
+    def create_or_update_users(organisation)
+      users_array(organisation).each do |user_info|
+        next if bot?(user_info)
+        puts user_info['name']
+        user = users_repository.user_from_slack_fetch(user_info)
+        organisation.add_user(user)
+      end
+    end
+
+    def users_array(organisation)
+      token = token(organisation)
+      client(token).users_list.members
+    end
+
+    def token(organisation)
+      organisation.token
+    end
+
+    def client(token)
+      Slack::RealTime::Client.new(token: token).web_client
+    end
+
+    def users_repository
+      @users_repository ||= UsersRepository.new
+    end
+
+    def bot?(user_info)
+      user_info.is_bot? || user_info.name.inquiry.slackbot?
+    end
+  end
+end

--- a/app/services/users/download_users.rb
+++ b/app/services/users/download_users.rb
@@ -1,16 +1,12 @@
 module Users
   class DownloadUsers
+    vattr_initialize [:organisation!]
+
     def call
-      fetch_users_from_every_organisation
+      create_or_update_users(organisation)
     end
 
     private
-
-    def fetch_users_from_every_organisation
-      Organisation.all.each do |organisation|
-        create_or_update_users(organisation)
-      end
-    end
 
     def create_or_update_users(organisation)
       users_array(organisation).each do |user_info|
@@ -38,7 +34,7 @@ module Users
     end
 
     def bot?(user_info)
-      user_info.is_bot? || user_info.name.inquiry.slackbot?
+      user_info['is_bot'] || user_info['name'].inquiry.slackbot?
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,87 @@
 require 'rails_helper'
 
+include OmniauthHelpers
+
 describe User do
   describe 'associations' do
     it { is_expected.to have_many(:memberships) }
     it { is_expected.to have_many(:organisations).through(:memberships) }
+  end
+
+  describe '.create_with_slack_fetch' do
+    let(:user_info) { users_list_array.first }
+    let(:organisation) { create(:organisation) }
+
+    subject { described_class.create_with_slack_fetch(user_info) }
+
+    context 'when there is a new user in Slack organisation' do
+      it 'creates new user' do
+        expect { subject }.to change { User.count }.by(1)
+      end
+
+      it 'creates new user with proper attributes', :aggregate_failures do
+        subject
+        expect(User.last.provider).to eq('slack')
+        expect(User.last.uid).to eq(user_info['id'])
+        expect(User.last.name).to eq(user_info['real_name'])
+        expect(User.last.email).to eq(user_info['profile']['email'])
+        expect(User.last.admin).to eq(user_info['is_admin'])
+        expect(User.last.avatar).to eq(user_info['profile']['image_512'])
+      end
+    end
+
+    context 'when user was already in the database' do
+      context 'when user uid is matching' do
+        let!(:user) { create(:user, uid: uid, name: 'Old Name') }
+        let(:uid) { user_info['id'] }
+
+        it 'updates user data' do
+          subject
+          expect(user.reload.name).to eq(user_info['real_name'])
+        end
+
+        it 'does not create new user' do
+          expect { subject }.not_to change { User.count }
+        end
+      end
+
+      context 'when user email is matching' do
+        let!(:user) { create(:user, email: email, name: 'Old Name') }
+        let(:email) { user_info['profile']['email'] }
+
+        it 'updates user data' do
+          subject
+          expect(user.reload.name).to eq(user_info['real_name'])
+        end
+
+        it 'does not create new user' do
+          expect { subject }.not_to change { User.count }
+        end
+      end
+    end
+
+    context 'when real_name in Slack response is blank' do
+      it 'uses mention in place of real name' do
+        user_info['real_name'] = ''
+        subject
+        expect(User.last.name).to eq(user_info['name'])
+      end
+    end
+
+    context 'when email in Slack response is nil' do
+      it 'asigns blank string in place of real name' do
+        user_info['profile']['email'] = nil
+        subject
+        expect(User.last.email).to eq('')
+      end
+    end
+
+    context 'when there is no info in Slack response about admins status' do
+      it 'asigns false' do
+        user_info['is_admin'] = nil
+        subject
+        expect(User.last.admin).to eq(false)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -106,7 +106,8 @@ describe Api::V1::Users do
       let(:members) { users_list_array(users_number: 1) }
 
       before do
-        allow_any_instance_of(Slack::RealTime::Client).to receive_message_chain(:web_client, :users_list) { users_list }
+        allow_any_instance_of(Slack::RealTime::Client)
+          .to receive_message_chain(:web_client, :users_list) { users_list }
         sign_in(membership)
         post '/api/v1/users/download_users'
       end

--- a/spec/services/users/download_users_spec.rb
+++ b/spec/services/users/download_users_spec.rb
@@ -13,7 +13,7 @@ describe Users::DownloadUsers do
       allow_any_instance_of(Slack::RealTime::Client).to receive_message_chain(:web_client, :users_list) { users_list }
     end
 
-    context 'when there is new user in Slack organisation' do
+    context 'when there is a new user in Slack organisation' do
       let(:members) { users_list_array(users_number: 1) }
 
       it 'creates new user' do

--- a/spec/services/users/download_users_spec.rb
+++ b/spec/services/users/download_users_spec.rb
@@ -97,5 +97,31 @@ describe Users::DownloadUsers do
         expect(user.reload.name).to eq(members.first['real_name'])
       end
     end
+
+    context 'when there are few organisations' do
+      let(:members) { users_list_array(users_number: 1) }
+      let(:uid) { members.first['id'] }
+      let(:email) { members.first['profile']['email'] }
+      let(:user_one) do
+        create(:user, uid: uid, email: email, name: 'Old Name')
+      end
+      let(:user_two) { create(:user, name: 'Other Name') }
+      let!(:organisation_one) { create(:organisation, users: [user_one]) }
+      let!(:organisation_two) { create(:organisation, users: [user_two]) }
+
+      subject { described_class.new(organisation: organisation_one).call }
+
+      it 'updates user data', :aggregate_failures do
+        expect(organisation_one.users.last.name).to eq(user_one.name)
+        subject
+        expect(user_one.reload.name).to eq(members.first['real_name'])
+      end
+
+      it 'updates users only from provided orgaisation', :aggregate_failures do
+        expect(organisation_two.users.last.name).to eq(user_two.name)
+        subject
+        expect(user_two.reload.name).to eq(user_two.name)
+      end
+    end
   end
 end

--- a/spec/services/users/download_users_spec.rb
+++ b/spec/services/users/download_users_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+include OmniauthHelpers
+
+describe Users::DownloadUsers do
+  describe '#call' do
+    let(:organisation) { create(:organisation) }
+    let(:users_list) { double('users_list', members: members) }
+
+    subject { described_class.new(organisation: organisation).call }
+
+    before do
+      allow_any_instance_of(Slack::RealTime::Client).to receive_message_chain(:web_client, :users_list) { users_list }
+    end
+
+    context 'when there is new user in Slack organisation' do
+      let(:members) { users_list_array(users_number: 1) }
+
+      it 'creates new user' do
+        expect { subject }.to change { User.count }.by(1)
+      end
+
+      it 'creates new user with proper attributes' do
+        subject
+        expect(User.last.uid).to eq(members.last['id'])
+      end
+
+      it 'adds user to organisation' do
+        expect { subject }.to change { organisation.users.count }.by(1)
+      end
+    end
+
+    context 'when there are few new users in the Slack organisation' do
+      let(:members) { users_list_array(users_number: 3) }
+
+      it 'creates few new users' do
+        expect { subject }.to change { User.count }.by(3)
+      end
+
+      it 'creates new user with proper attributes', :aggregate_failures do
+        subject
+        expect(User.first.uid).to eq(members.first['id'])
+        expect(User.last.uid).to eq(members.last['id'])
+      end
+
+      it 'adds users to organisation' do
+        expect { subject }.to change { organisation.users.count }.by(3)
+      end
+    end
+
+    context 'when an user is a bot' do
+      let(:members) { users_list_array(users_number: 2, is_bot: true) }
+
+      it 'does not create a new user' do
+        expect { subject }.not_to change { User.count }
+      end
+
+      it 'omits only bot users and creates normal user' do
+        members.second['is_bot'] = false
+        expect { subject }.to change { User.count }.by(1)
+      end
+
+      it 'does not add user to organisation' do
+        expect { subject }.not_to change { organisation.users.count }
+      end
+    end
+
+    context 'when an user has "slackbot" name' do
+      let(:members) { users_list_array(users_number: 2) }
+
+      before do
+        members.first['name'] = 'slackbot'
+      end
+
+      it 'does not create a new user' do
+        members.second['name'] = 'slackbot'
+        expect { subject }.not_to change { User.count }
+      end
+
+      it 'omits only bot users and creates normal user' do
+        expect { subject }.to change { User.count }.by(1)
+      end
+    end
+
+    context 'when user was already in the database' do
+      let(:members) { users_list_array(users_number: 1) }
+      let(:uid) { members.first['id'] }
+      let(:email) { members.first['profile']['email'] }
+      let(:user) do
+        create(:user, uid: uid, email: email, name: 'Old Name')
+      end
+      let(:organisation) { create(:organisation, users: [user]) }
+
+      it 'updates user data', :aggregate_failures do
+        expect(organisation.users.last.name).to eq(user.name)
+        subject
+        expect(user.reload.name).to eq(members.first['real_name'])
+      end
+    end
+  end
+end

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -30,4 +30,33 @@ module OmniauthHelpers
       'credentials' => { 'token' => token },
     }
   end
+
+  def users_list_array(users_number: 1,
+                       email: 'aaa@bbb.cc',
+                       id: 'slack_id',
+                       name: 'mention',
+                       real_name: 'John Doe',
+                       big_avatar: 'slack.com/sample_avatar.png',
+                       is_admin: false,
+                       is_bot: false)
+    users_list_array = []
+    users_number.times do |i|
+      i = i.to_s
+      users_list_array <<
+        {
+          'id' => id + i,
+          'name' => name + i,
+          'deleted' => false,
+          'real_name' => real_name + i,
+          'profile' =>
+          {
+            'email' => i + email,
+            'image_512' => i + big_avatar,
+          },
+          'is_admin' => is_admin,
+          'is_bot' => is_bot,
+        }
+    end
+    users_list_array
+  end
 end


### PR DESCRIPTION
Allow admin of the Slack organisation to update all users to the state from Slack - emails, avatars, names etc. Feature uses Slack API to request that data. Bot users are not being saved.