### PR TITLE
Prop-78 Use smaller avatar when bigger is not available

### DIFF
--- a/app/services/users/create_from_slack_fetch.rb
+++ b/app/services/users/create_from_slack_fetch.rb
@@ -53,7 +53,7 @@ module Users
 
     def choose_avatar
       user_info['profile']['image_512'] ||
-        user_info['profile']['image_original'] || 
+        user_info['profile']['image_original'] ||
         user_info['profile']['image_192']
     end
   end

--- a/app/services/users/create_from_slack_fetch.rb
+++ b/app/services/users/create_from_slack_fetch.rb
@@ -43,12 +43,18 @@ module Users
         name: name_from_user_info,
         email: user_info['profile']['email'] || '',
         admin: user_info['is_admin'] || false,
-        avatar: user_info['profile']['image_512'],
+        avatar: choose_avatar,
       }
     end
 
     def name_from_user_info
       user_info['real_name'].presence || user_info['name']
+    end
+
+    def choose_avatar
+      user_info['profile']['image_512'] ||
+        user_info['profile']['image_original'] || 
+        user_info['profile']['image_192']
     end
   end
 end

--- a/spec/services/users/create_from_slack_fetch_spec.rb
+++ b/spec/services/users/create_from_slack_fetch_spec.rb
@@ -197,5 +197,20 @@ describe Users::CreateFromSlackFetch do
         expect(User.last.admin).to eq(false)
       end
     end
+
+    context 'when user has smaller avatar' do
+      it 'uses "original_image" first' do
+        user_info['profile']['image_512'] = nil
+        subject
+        expect(User.last.avatar).to eq(user_info['profile']['image_original'])
+      end
+
+      it 'uses "image_192" when no bigger image is available' do
+        user_info['profile']['image_512'] = nil
+        user_info['profile']['image_original'] = nil
+        subject
+        expect(User.last.avatar).to eq(user_info['profile']['image_192'])
+      end
+    end
   end
 end

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -54,7 +54,9 @@ module OmniauthHelpers
           'profile' =>
           {
             'email' => i + email,
+            'image_192' => i + '_small_version_' + big_avatar,
             'image_512' => i + big_avatar,
+            'image_original' => i + '_original_' + big_avatar,
             'guest_channels' => is_guest ? ['chann_id'] : nil,
           },
           'is_admin' => is_admin,


### PR DESCRIPTION
Use smaller avatar when bigger is not available - info from Slack organisation