### PR TITLE
Prop-81 match email without domain

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,33 +11,11 @@ class User < ActiveRecord::Base
   end
 
   def self.create_with_omniauth(auth)
-    return update_with_omniauth(auth) if omniauth_user(auth)
-    create! omniauth_attrs(auth)
-  end
-
-  def self.update_with_omniauth(auth)
-    omniauth_user(auth).tap do |user|
-      user.update omniauth_attrs(auth)
-    end
+    Users::CreateFromOmniauth.new(auth: auth).call
   end
 
   def self.create_from_slack(member)
     create! slack_attrs(member)
-  end
-
-  def self.omniauth_user(auth)
-    find_by(uid: auth['uid']) || find_by(email: auth['info']['email'])
-  end
-
-  def self.omniauth_attrs(auth)
-    {
-      provider: auth['provider'],
-      uid: auth['uid'],
-      name: auth['info']['name'] || '',
-      email: auth['info']['email'] || '',
-      admin: auth['info']['is_admin'] || false,
-      avatar: big_avatar_512(auth) || small_avatar_192(auth),
-    }
   end
 
   def self.slack_attrs(member)
@@ -48,17 +26,5 @@ class User < ActiveRecord::Base
       name: member['profile']['real_name'] || '',
       email: member['profile']['email'] || '',
     }
-  end
-
-  class << self
-    private
-
-    def big_avatar_512(auth)
-      auth.dig('extra', 'user_info', 'user', 'profile', 'image_512')
-    end
-
-    def small_avatar_192(auth)
-      auth['info']['image']
-    end
   end
 end

--- a/app/repositories/users_repository.rb
+++ b/app/repositories/users_repository.rb
@@ -21,10 +21,6 @@ class UsersRepository
     User.create_with_omniauth(auth)
   end
 
-  def user_from_slack_fetch(user_info)
-    User.create_with_slack_fetch(user_info)
-  end
-
   def user_from_slack(member)
     find_by_member(member) || (report_matching_error(member) && User.create_from_slack(member))
   end

--- a/app/services/users/create_from_omniauth.rb
+++ b/app/services/users/create_from_omniauth.rb
@@ -10,9 +10,7 @@ module Users
     private
 
     def update_with_slack_fetch
-      slack_user.tap do |user|
-        user.update omniauth_attrs
-      end
+      slack_user.tap { |user| user.update omniauth_attrs }
     end
 
     def slack_user

--- a/app/services/users/create_from_omniauth.rb
+++ b/app/services/users/create_from_omniauth.rb
@@ -1,0 +1,61 @@
+module Users
+  class CreateFromOmniauth
+    pattr_initialize [:auth!]
+
+    def call
+      return update_with_slack_fetch if slack_user.present?
+      User.create! omniauth_attrs
+    end
+
+    private
+
+    def update_with_slack_fetch
+      slack_user.tap do |user|
+        user.update omniauth_attrs
+      end
+    end
+
+    def slack_user
+      @slack_user ||= user_found_by_uid || user_found_by_email
+    end
+
+    def user_found_by_uid
+      User.find_by(uid: auth['uid'])
+    end
+
+    def user_found_by_email
+      User.find_by('email LIKE ?', "#{email_without_domain}%") if email_without_domain.present?
+    end
+
+    def email_without_domain
+      auth['info']['email']&.split('@')&.first
+    end
+
+    def omniauth_attrs
+      {
+        provider: auth['provider'],
+        uid: auth['uid'],
+        name: name_from_auth,
+        email: auth['info']['email'] || '',
+        admin: auth['info']['is_admin'] || false,
+        avatar: big_avatar_512 || small_avatar_192,
+      }
+    end
+
+    def name_from_auth
+      real_name || auth['info']['name'].presence || ''
+    end
+
+    def real_name
+      auth.dig('extra', 'user_info', 'user', 'profile', 'real_name')
+    end
+
+    def big_avatar_512
+      auth.dig('extra', 'user_info', 'user', 'profile', 'image_512')
+    end
+
+    def small_avatar_192
+      auth['info']['image']
+    end
+  end
+end

--- a/app/services/users/create_from_slack_fetch.rb
+++ b/app/services/users/create_from_slack_fetch.rb
@@ -15,8 +15,19 @@ module Users
     end
 
     def slack_user
-      @slack_user ||= User.find_by(uid: user_info['id']) ||
-                      User.find_by(email: user_info['profile']['email'])
+      @slack_user ||= user_found_by_uid || user_found_by_email
+    end
+
+    def user_found_by_uid
+      User.find_by(uid: user_info['id'])
+    end
+
+    def user_found_by_email
+      User.find_by('email LIKE ?', "#{email_without_domain}%") if email_without_domain.present?
+    end
+
+    def email_without_domain
+      user_info['profile']['email']&.split('@')&.first
     end
 
     def manage_archivisation

--- a/spec/services/users/create_from_omniauth_spec.rb
+++ b/spec/services/users/create_from_omniauth_spec.rb
@@ -135,8 +135,6 @@ describe Users::CreateFromOmniauth do
       it 'does not update user - raises validation error' do
         auth['extra']['user_info']['user']['profile']['real_name'] = nil
         auth['info']['name'] = nil
-        # subject
-        # expect(User.last.name).to eq(auth['info']['nickname'])
         expect { subject }.to raise_exception(ActiveRecord::RecordInvalid)
       end
     end

--- a/spec/services/users/create_from_omniauth_spec.rb
+++ b/spec/services/users/create_from_omniauth_spec.rb
@@ -94,7 +94,7 @@ describe Users::CreateFromOmniauth do
 
         context 'when user has two accounts and one is archived' do
           let!(:user_second_account) { create(:user, email: email, archived_at: 3.days.ago) }
-          let!(:user_sec_acc_attributes) { user_second_account.attributes }
+          let!(:user_sec_acc_attributes) { user_second_account.attributes.to_s }
 
           it 'does not create new user' do
             expect { subject }.not_to change(User, :count)
@@ -102,7 +102,8 @@ describe Users::CreateFromOmniauth do
 
           it 'does not update archived account' do
             subject
-            expect(user_second_account.reload.attributes).to eq(user_sec_acc_attributes)
+            users_attributes = user_second_account.reload.attributes.to_s
+            expect(users_attributes).to eq(user_sec_acc_attributes)
           end
         end
       end
@@ -110,13 +111,14 @@ describe Users::CreateFromOmniauth do
       context 'when both uid and email without domain matches' do
         let!(:user) { create(:user, uid: uid) }
         let!(:user_with_email) { create(:user, email: email + 'domain.com') }
-        let!(:user_with_email_attributes) { user_with_email.attributes }
+        let!(:user_with_email_attributes) { user_with_email.attributes.to_s }
 
         include_examples 'assign proper attributes to user'
 
         it 'does not update user with matching email' do
           subject
-          expect(user_with_email.reload.attributes).to eq(user_with_email_attributes)
+          users_attributes = user_with_email.reload.attributes.to_s
+          expect(users_attributes).to eq(user_with_email_attributes)
         end
       end
     end
@@ -162,6 +164,5 @@ describe Users::CreateFromOmniauth do
         expect(User.last.avatar).to eq(auth['info']['image'])
       end
     end
-
   end
 end

--- a/spec/services/users/create_from_omniauth_spec.rb
+++ b/spec/services/users/create_from_omniauth_spec.rb
@@ -1,0 +1,167 @@
+require 'rails_helper'
+
+include OmniauthHelpers
+
+describe Users::CreateFromOmniauth do
+  describe '#call' do
+    shared_examples 'assign proper attributes to user' do
+      it 'assigns proper attributes to user', :aggregate_failures do
+        subject
+        user.reload
+        expect(user.provider).to eq('slack')
+        expect(user.uid).to eq(auth['uid'])
+        expect(user.name).to eq(auth.dig('extra', 'user_info', 'user', 'profile', 'real_name'))
+        expect(user.email).to eq(auth['info']['email'])
+        expect(user.admin).to eq(auth['info']['is_admin'])
+        expect(user.avatar).to eq(auth.dig('extra', 'user_info', 'user', 'profile', 'image_512'))
+      end
+    end
+
+    let(:auth) { create_auth }
+    subject { described_class.new(auth: auth).call }
+
+    context 'when there is a new user in Slack organisation' do
+      it 'assigns proper attributes to user', :aggregate_failures do
+        subject
+        user = User.last
+        expect(user.provider).to eq('slack')
+        expect(user.uid).to eq(auth['uid'])
+        expect(user.name).to eq(auth.dig('extra', 'user_info', 'user', 'profile', 'real_name'))
+        expect(user.email).to eq(auth['info']['email'])
+        expect(user.admin).to eq(auth['info']['is_admin'])
+        expect(user.avatar).to eq(auth.dig('extra', 'user_info', 'user', 'profile', 'image_512'))
+      end
+
+      it 'creates new user' do
+        expect { subject }.to change(User, :count).by(1)
+      end
+
+      it 'returns user object' do
+        expect(subject).to eq(User.last)
+      end
+    end
+
+    context 'when user has already been in the database', :freeze_time do
+      let(:uid) { auth['uid'] }
+      let(:email) { auth['info']['email'] }
+
+      context 'when user uid matches' do
+        let!(:user) { create(:user, uid: uid, name: 'Old Name') }
+
+        include_examples 'assign proper attributes to user'
+
+        it 'does not create new user' do
+          expect { subject }.not_to change(User, :count)
+        end
+
+        it 'returns user object' do
+          expect(subject).to eq(user.reload)
+        end
+      end
+
+      context 'when user email matches' do
+        let!(:user) { create(:user, email: email, name: 'Old Name') }
+
+        include_examples 'assign proper attributes to user'
+
+        it 'does not create new user' do
+          expect { subject }.not_to change(User, :count)
+        end
+
+        it 'returns user object' do
+          expect(subject).to eq(user.reload)
+        end
+      end
+
+      context 'when user email matches but without domain' do
+        let!(:user) { create(:user, email: email + 'domain.com', name: 'Old Name') }
+
+        include_examples 'assign proper attributes to user'
+
+        it 'does not create new user' do
+          expect { subject }.not_to change(User, :count)
+        end
+
+        context 'when user account is archived' do
+          let!(:user) { create(:user, email: email + 'domain.com', archived_at: 3.days.ago) }
+
+          include_examples 'assign proper attributes to user'
+
+          it 'does not create new user' do
+            expect { subject }.not_to change(User, :count)
+          end
+        end
+
+        context 'when user has two accounts and one is archived' do
+          let!(:user_second_account) { create(:user, email: email, archived_at: 3.days.ago) }
+          let!(:user_sec_acc_attributes) { user_second_account.attributes }
+
+          it 'does not create new user' do
+            expect { subject }.not_to change(User, :count)
+          end
+
+          it 'does not update archived account' do
+            subject
+            expect(user_second_account.reload.attributes).to eq(user_sec_acc_attributes)
+          end
+        end
+      end
+
+      context 'when both uid and email without domain matches' do
+        let!(:user) { create(:user, uid: uid) }
+        let!(:user_with_email) { create(:user, email: email + 'domain.com') }
+        let!(:user_with_email_attributes) { user_with_email.attributes }
+
+        include_examples 'assign proper attributes to user'
+
+        it 'does not update user with matching email' do
+          subject
+          expect(user_with_email.reload.attributes).to eq(user_with_email_attributes)
+        end
+      end
+    end
+
+    context 'when real_name in Slack response is blank' do
+      it 'uses name in place of real name' do
+        auth['extra']['user_info']['user']['profile']['real_name'] = nil
+        subject
+        expect(User.last.name).to eq(auth['info']['name'])
+      end
+    end
+
+    context 'when real_name and name in Slack response is blank' do
+      it 'does not update user - raises validation error' do
+        auth['extra']['user_info']['user']['profile']['real_name'] = nil
+        auth['info']['name'] = nil
+        # subject
+        # expect(User.last.name).to eq(auth['info']['nickname'])
+        expect { subject }.to raise_exception(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context 'when email in Slack response is nil' do
+      it 'assigns blank string in place of email' do
+        auth['info']['email'] = nil
+        subject
+        expect(User.last.email).to eq('')
+      end
+    end
+
+    context 'when there is no info in Slack response about admins status' do
+      it 'assigns false to #admin' do
+        auth['info']['is_admin'] = nil
+        subject
+        expect(User.last.admin).to eq(false)
+      end
+    end
+
+    context 'when user has smaller avatar' do
+      it 'uses "image_192" when no bigger image is available' do
+        auth['extra']['user_info']['user']['profile']['image_512'] = nil
+        subject
+        expect(User.last.avatar).to eq(auth['info']['image'])
+      end
+    end
+
+  end
+end

--- a/spec/services/users/create_from_slack_fetch_spec.rb
+++ b/spec/services/users/create_from_slack_fetch_spec.rb
@@ -8,12 +8,7 @@ describe Users::CreateFromSlackFetch do
       it 'assigns proper attributes to user', :aggregate_failures do
         subject
         user.reload
-        expect(user.provider).to eq('slack')
-        expect(user.uid).to eq(user_info['id'])
-        expect(user.name).to eq(user_info['real_name'])
-        expect(user.email).to eq(user_info['profile']['email'])
-        expect(user.admin).to eq(user_info['is_admin'])
-        expect(user.avatar).to eq(user_info['profile']['image_512'])
+        assert_user(user)
       end
     end
 
@@ -57,12 +52,7 @@ describe Users::CreateFromSlackFetch do
       it 'assigns proper attributes to user', :aggregate_failures do
         subject
         user = User.last
-        expect(user.provider).to eq('slack')
-        expect(user.uid).to eq(user_info['id'])
-        expect(user.name).to eq(user_info['real_name'])
-        expect(user.email).to eq(user_info['profile']['email'])
-        expect(user.admin).to eq(user_info['is_admin'])
-        expect(user.avatar).to eq(user_info['profile']['image_512'])
+        assert_user(user)
       end
 
       it 'creates new user with proper attributes', :aggregate_failures do
@@ -270,5 +260,16 @@ describe Users::CreateFromSlackFetch do
         expect(User.last.avatar).to eq(user_info['profile']['image_192'])
       end
     end
+  end
+
+  private
+
+  def assert_user(user)
+    expect(user.provider).to eq('slack')
+    expect(user.uid).to eq(user_info['id'])
+    expect(user.name).to eq(user_info['real_name'])
+    expect(user.email).to eq(user_info['profile']['email'])
+    expect(user.admin).to eq(user_info['is_admin'])
+    expect(user.avatar).to eq(user_info['profile']['image_512'])
   end
 end

--- a/spec/services/users/create_from_slack_fetch_spec.rb
+++ b/spec/services/users/create_from_slack_fetch_spec.rb
@@ -115,7 +115,7 @@ describe Users::CreateFromSlackFetch do
 
         context 'when user has two accounts and one is archived' do
           let!(:user_second_account) { create(:user, email: email, archived_at: 3.days.ago) }
-          let!(:user_sec_acc_attributes) { user_second_account.attributes }
+          let!(:user_sec_acc_attributes) { user_second_account.attributes.to_s }
 
           it 'does not create new user' do
             expect { subject }.not_to change(User, :count)
@@ -123,7 +123,8 @@ describe Users::CreateFromSlackFetch do
 
           it 'does not update archived account' do
             subject
-            expect(user_second_account.reload.attributes).to eq(user_sec_acc_attributes)
+            users_attributes = user_second_account.reload.attributes.to_s
+            expect(users_attributes).to eq(user_sec_acc_attributes)
           end
         end
       end
@@ -131,13 +132,14 @@ describe Users::CreateFromSlackFetch do
       context 'when both uid and email without domain matches' do
         let!(:user) { create(:user, uid: uid) }
         let!(:user_with_email) { create(:user, email: email + 'domain.com') }
-        let!(:user_with_email_attributes) { user_with_email.attributes }
+        let!(:user_with_email_attributes) { user_with_email.attributes.to_s }
 
         include_examples 'assign proper attributes to user'
 
         it 'does not update user with matching email' do
           subject
-          expect(user_with_email.reload.attributes).to eq(user_with_email_attributes)
+          users_attributes = user_with_email.reload.attributes.to_s
+          expect(users_attributes).to eq(user_with_email_attributes)
         end
       end
 

--- a/spec/services/users/download_users_spec.rb
+++ b/spec/services/users/download_users_spec.rb
@@ -144,7 +144,6 @@ describe Users::DownloadUsers do
 
       before do
         members.first['deleted'] = true
-        allow_any_instance_of(UsersRepository).to receive(:user_from_slack_fetch) { nil }
       end
 
       it 'does not add user to organisation' do

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -10,7 +10,7 @@ module OmniauthHelpers
       'provider' => 'slack',
       'uid' => 'auth_uid',
       'info' => {
-        'name' => 'Tod tod',
+        'name' => 'Tod T',
         'nickname' => 'tod',
         'email' => email,
         'team_id' => team_id,
@@ -22,6 +22,7 @@ module OmniauthHelpers
         'user_info' => {
           'user' => {
             'profile' => {
+              'real_name' => 'Tod Tod',
               'image_512' => big_avatar,
             },
           },


### PR DESCRIPTION
After integrating signing in with Slack, few users experienced a bug - creation of new account. It occurs when user was using different email address during previous integration with google. To solve this issue I change matching user to check email address but without domain.

Changes implemented in signing in process and users fetch process.

Some legacy code deleted.