### PR TITLE
PROP-84 Turn off magic comment rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,8 @@ Style/DotPosition:
   EnforcedStyle: leading
 SignalException:
   Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 Style/TrailingCommaInLiteral:


### PR DESCRIPTION
Rubocop required `Missing magic comment # frozen_string_literal: true.` - turn it off