### PR TITLE
PROP-85 Add sync users button

### DIFF
--- a/app/controllers/api/v1/users.rb
+++ b/app/controllers/api/v1/users.rb
@@ -38,6 +38,11 @@ module Api
         post :download_users do
           authenticate_admin!
           DownloadUsersJob.perform_later(organisation: current_organisation)
+          # Redirection is a hack letting us use this action in
+          # the Rails view (settings/index.html.haml).
+          # It has to be removed when new react frontend will be provided
+          # TODO: remove redirection, when fronts will be ready
+          redirect '/app/users'
           { text: I18n.t('props.messages.background_process') }
         end
       end

--- a/app/views/settings/index.html.haml
+++ b/app/views/settings/index.html.haml
@@ -35,3 +35,7 @@
             If not set, default Slack channel is
             %code= AppConfig.slack.default_channel
         = f.submit "Update Slack Channel", class: 'btn btn-primary'
+      %h2 Sync users with Slack organisation
+      %p Users will be updated to the Slack state. Avatars and names will be updated and new users created.
+      %p Users deleted from the Slack organisation will be archived in Kudos.
+      = link_to("Sync users with Slack", "/api/v1/users/download_users", method: :post, class: 'btn btn-primary')

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -106,6 +106,7 @@ describe Api::V1::Users do
       let(:response_body) do
         { text: 'Processing in the background' }
       end
+      let(:redirection_msg) { 'This resource has been moved temporarily to /app/users.' }
 
       before do
         allow_any_instance_of(Slack::RealTime::Client)
@@ -117,11 +118,15 @@ describe Api::V1::Users do
       after { sign_out }
 
       it 'has OK response status' do
-        expect(response).to have_http_status(201)
+        expect(response).to have_http_status(302)
+        # 302 because of redirection - see explanation in the controller
+        # expect(response).to have_http_status(201)
       end
 
       it 'has proper response body' do
-        expect(response.body).to eq(response_body.to_json)
+        expect(response.body).to eq(redirection_msg.to_json)
+        # Changed because of redirection - see explanation in the controller
+        # expect(response.body).to eq(response_body.to_json)
       end
     end
   end


### PR DESCRIPTION
Add button for admin for syncing users with Slack organisation. Solution is kinda hacky, but will be used only until new fronts will be provided.