### PR TITLE
[BN-996] Update docker image vulnerabilities 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ defaults: &defaults
     - image: circleci/postgres:latest
       environment:
         - POSTGRES_USER=props
+        - POSTGRES_HOST_AUTH_METHOD=trust
 
 version: 2
 jobs:

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/netguru/ng-ruby:2.5.1
 
+# Install latest security updates
+RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"
+
 ## Passenger
 RUN /opt/passenger/install
 

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -2,6 +2,9 @@ FROM quay.io/netguru/baseimage:0.10.0
 
 ENV RUBY_VERSION 2.5.1
 
+# Install latest security updates
+RUN apt-get update && apt-get upgrade --allow-unauthenticated -y -o Dpkg::Options::="--force-confold"
+
 ## Install Ruby
 RUN \
   apt-get update -q && \


### PR DESCRIPTION
1. Add command to install latest security updates,
2. Add `POSTGRES_HOST_AUTH_METHOD=trust` to CI.
