### PR TITLE
load rake tasks not through application

### DIFF
--- a/config/cronotab.rb
+++ b/config/cronotab.rb
@@ -1,5 +1,5 @@
 require 'rake'
-Rails.application.load_tasks
+Rails.app_class.load_tasks
 
 module CronTasks
   module EmailDigests


### PR DESCRIPTION
props emails are not being sent. From logs it seems that cron is running well but the rake tasks are not being executed. The change is in loading rake tasks the same way as it is done in gems documentation.