### PR TITLE
[BN-996] Update CircleCI ruby image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/props
   docker:
-    - image: circleci/ruby:2.5.1-node-browsers
+    - image: circleci/ruby:2.6.6-node-browsers
       environment:
         - RAILS_ENV=test
     - image: circleci/postgres:latest
@@ -181,12 +181,12 @@ staging_only: &staging_only
       only:
         - staging
         - codedeploy
-    
+
 production_only: &production_only
   filters:
     branches:
       only: master
-    
+
 workflows:
   version: 2
   build_and_deploy:


### PR DESCRIPTION
https://netguru.atlassian.net/browse/BN-996

I've checked the images we're using and after checking many images from docker hub (https://hub.docker.com/r/circleci/ruby) with trivy I chose the one with the smallest amount of issues detected 🙈  I already created a backlog task for finding the image with no issues at all, for now we need to have one improvement at a time.